### PR TITLE
Update to allow use on 1.16.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,6 @@ dependencies {
 	mappings "net.fabricmc:yarn:${project.yarn_mappings}:v2"
 	modCompile "net.fabricmc:fabric-loader:${project.loader_version}"
 
-	// Fabric API. This is technically optional, but you probably want it anyway.
-	modCompile "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
-
 	// PSA: Some older mods, compiled on Loom 0.2.1, might have outdated Maven POMs.
 	// You may need to force-disable transitiveness on them.
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 	# check these on https://fabricmc.net/use
-	minecraft_version=1.16
-	yarn_mappings=1.16+build.4
-	loader_version=0.8.8+build.202
+	minecraft_version=1.16.3
+	yarn_mappings=1.16.3+build.47
+	loader_version=0.10.2+build.210
 
 # Mod Properties
 	mod_version = 1.0.1
@@ -13,5 +13,3 @@ org.gradle.jvmargs=-Xmx1G
 	archives_base_name = step-height-entity-attribute
 
 # Dependencies
-	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
-	fabric_version=0.13.1+build.370-1.16

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -27,8 +27,7 @@
 	],
 
 	"depends": {
-		"fabricloader": ">=0.4.0",
-		"fabric": "*"
+		"fabricloader": ">=0.4.0"
 	},
 	"suggests": {
 		"flamingo": "*"


### PR DESCRIPTION
This required removing the dependency on fabric-api-biomes, as it has not yet been ported to 1.16.3. I discovered that none of fabric-api was necessary, so I removed the dependency on it.